### PR TITLE
extract pixel number as NDArray attributes

### DIFF
--- a/dxpApp/src/NDDxp.cpp
+++ b/dxpApp/src/NDDxp.cpp
@@ -303,6 +303,8 @@ NDDxp::NDDxp(const char *portName, int nChannels, int maxBuffers, size_t maxMemo
         sprintf(attrTriggersDescription[i], "Trigger counts %d", i); 
         sprintf(attrOutputCountsName[i], "OutputCounts_%d", i); 
         sprintf(attrOutputCountsDescription[i], "Output counts %d", i);
+        sprintf(attrPixelNumberName[i], "PixelNumber_%d", i);
+        sprintf(attrPixelNumberDescription[i], "Pixel number %d", i);
     } 
 
     /* Start up acquisition thread */
@@ -1544,6 +1546,7 @@ asynStatus NDDxp::getMappingData()
                     pArray->pAttributeList->add(attrLiveTimeName[channel],     attrLiveTimeDescription[channel],     NDAttrFloat64, &triggerLiveTime);
                     pArray->pAttributeList->add(attrTriggersName[channel],     attrTriggersDescription[channel],     NDAttrInt32,   &pMPH->triggers);
                     pArray->pAttributeList->add(attrOutputCountsName[channel], attrOutputCountsDescription[channel], NDAttrInt32,   &pMPH->outputCounts);
+                    pArray->pAttributeList->add(attrPixelNumberName[channel],  attrPixelNumberDescription[channel],  NDAttrInt32,   &pMPH->pixelNumber);
                     pBuffer += arraySize;
                     pOut += pMPH->spectrumSize;
                 }

--- a/dxpApp/src/NDDxp.h
+++ b/dxpApp/src/NDDxp.h
@@ -313,6 +313,8 @@ private:
     char attrTriggersDescription    [MAX_CHANNELS_PER_SYSTEM][MAX_ATTR_NAME_LEN];
     char attrOutputCountsName       [MAX_CHANNELS_PER_SYSTEM][MAX_ATTR_NAME_LEN];
     char attrOutputCountsDescription[MAX_CHANNELS_PER_SYSTEM][MAX_ATTR_NAME_LEN];
+    char attrPixelNumberName        [MAX_CHANNELS_PER_SYSTEM][MAX_ATTR_NAME_LEN];
+    char attrPixelNumberDescription [MAX_CHANNELS_PER_SYSTEM][MAX_ATTR_NAME_LEN];
  
 };
 


### PR DESCRIPTION
This information becomes useful when there are buffer overflow errors and certain pixels are skipped.